### PR TITLE
feat/UKET-84: 어드민 삭제 기능 수정

### DIFF
--- a/apps/admin/app/(main)/(super-admin)/super-admin/user-manage/_components/user-remove-button.tsx
+++ b/apps/admin/app/(main)/(super-admin)/super-admin/user-manage/_components/user-remove-button.tsx
@@ -11,18 +11,21 @@ import {
 } from "@ui/components/ui/dialog";
 import { Trash2Icon } from "@ui/components/ui/icon";
 import { useMutationRemoveAdmin } from "@uket/api/mutations/use-mutation-manage-admin";
-import { useSearchParams } from "next/navigation";
+import { clearToken, deleteCookie, getCookie } from "@uket/util/cookie-client";
+import { redirect, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 interface UserRemoveButtonProps {
   userId: number;
   userName: string;
+  userEmail: string;
 }
 
 // TODO: 사용자 이름 연동 및 핸들러 추가
 export default function UserRemoveButton({
   userId,
   userName,
+  userEmail,
 }: UserRemoveButtonProps) {
   const searchParams = useSearchParams();
   const pageParam = searchParams.get("page") as string;
@@ -36,6 +39,14 @@ export default function UserRemoveButton({
       {
         onSuccess: () => {
           setOpen(false);
+
+          const currentLoginedUserEmail = getCookie("admin-email");
+          
+          if (currentLoginedUserEmail === userEmail) {
+            clearToken("admin", "access");
+            deleteCookie("admin-email");
+            redirect("/");
+          }
         },
       },
     );

--- a/apps/admin/app/(main)/(super-admin)/super-admin/user-manage/_components/user-table-section.tsx
+++ b/apps/admin/app/(main)/(super-admin)/super-admin/user-manage/_components/user-table-section.tsx
@@ -57,8 +57,8 @@ export const columns: ColumnDef<Entry>[] = [
     enableHiding: false,
     header: "변경",
     cell: ({ row }) => {
-      const { id, name } = row.original;
-      return <UserRemoveButton userId={id} userName={name} />;
+      const { id, name, email } = row.original;
+      return <UserRemoveButton userId={id} userName={name} userEmail={email} />;
     },
   },
 ];

--- a/apps/admin/hooks/use-login-form.ts
+++ b/apps/admin/hooks/use-login-form.ts
@@ -6,7 +6,10 @@ import { z } from "zod";
 
 import { useMutationAdminLogin } from "@uket/api/mutations/use-mutation-admin-login";
 import { AdminLoginResponse } from "@uket/api/types/admin-auth";
-import { setTokenServer } from "@uket/util/cookie-server";
+import {
+  setCookieServerForAdmin,
+  setTokenServer,
+} from "@uket/util/cookie-server";
 import { useRouter } from "next/navigation";
 
 export type FormSchemaType = z.infer<typeof LoginFormSchema>;
@@ -45,8 +48,9 @@ export const useLoginForm = () => {
         password,
       },
       {
-        onSuccess: async ({ accessToken }: AdminLoginResponse) => {
+        onSuccess: async ({ accessToken, email }: AdminLoginResponse) => {
           await setTokenServer("admin", "access", accessToken);
+          await setCookieServerForAdmin("admin-email", email);
           router.push("/qr-scan");
         },
       },

--- a/packages/api/src/types/admin-auth.ts
+++ b/packages/api/src/types/admin-auth.ts
@@ -8,7 +8,8 @@ export type AdminLoginRequestParams = {} & AccountInfo;
 export type AdminLoginResponse = {
   accessToken: string;
   name: string;
-  authority: string;
+  email: string;
+  isSuperAdmin: boolean;
 };
 
 export type AdminSignupRequestParams = {

--- a/packages/util/src/cookie-server.ts
+++ b/packages/util/src/cookie-server.ts
@@ -42,6 +42,13 @@ export const clearTokenServer = async (
   await deleteCookie(tokenName, { cookies });
 };
 
+export const setCookieServerForAdmin = async (name: string, value: string) => {
+  await setCookie(name, value, {
+    ...ADMIN_OPTIONS,
+    cookies,
+  });
+};
+
 export {
   deleteCookie as deleteCookieServer,
   getCookie as getCookieServer,


### PR DESCRIPTION
## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 어드민 삭제 시나리오 반영
  - [ ] 본인 삭제 시 로그인 페이지로 리다이렉트
- [x] 어드민 로그인 반환 데이터 타입 변경
- [x] 어드민 삭제 시나리오를 위해 이메일을 쿠키에 저장하는 기능 추가

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점

## 💬 리뷰 요구사항(선택)

