### PR TITLE
feat: 어드민 회원가입 api 연결

### DIFF
--- a/apps/admin/app/(auth)/_components/signup-auth-section.tsx
+++ b/apps/admin/app/(auth)/_components/signup-auth-section.tsx
@@ -13,7 +13,7 @@ import { Input } from "@uket/ui/components/ui/input";
 import { useSignupForm } from "../../../hooks/use-signup-form";
 
 export default function SignupAuthSection() {
-  const { form, onSubmit } = useSignupForm();
+  const { form, onSubmit, error } = useSignupForm();
   const { isValid } = form.formState;
 
   return (
@@ -85,7 +85,7 @@ export default function SignupAuthSection() {
             />
           </div>
           <div className="h-5 text-center text-sm text-[#EF4444] sm:text-left">
-            에러
+            {error}
           </div>
 
           <Button

--- a/apps/admin/app/(auth)/signup/page.tsx
+++ b/apps/admin/app/(auth)/signup/page.tsx
@@ -8,8 +8,10 @@ export default async function Page() {
   return (
     <section
       className={cn(
-        "flex flex-col gap-11 relative my-[-2rem] mx-[-3rem] py-4 px-8 bg-[#F0EDFD]",
+        "flex flex-col gap-11 relative py-4 px-4 bg-[#F0EDFD]",
+        "md:my-[-2rem] md:mx-[-3rem] md:px-8",
         !isMobileDevice && "rounded-xl",
+        isMobileDevice && "w-screen left-1/2 -ml-[50vw]",
       )}
     >
       <SignupAuthSection />

--- a/apps/admin/hooks/use-signup-form.ts
+++ b/apps/admin/hooks/use-signup-form.ts
@@ -68,7 +68,7 @@ export const useSignupForm = () => {
         token,
       },
       {
-        onSuccess: async () => {
+        onSuccess: () => {
           router.replace("/");
         },
       },

--- a/apps/admin/hooks/use-signup-form.ts
+++ b/apps/admin/hooks/use-signup-form.ts
@@ -2,8 +2,10 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter, useSearchParams } from "next/navigation";
+
 import { UseFormReturn, useForm } from "react-hook-form";
 import { z } from "zod";
+import { useMutationAdminSignup } from "../../../packages/api/src/mutations/use-mutation-admin-signup";
 
 export type FormSchemaType = z.infer<typeof SignupFormSchema>;
 export type FormType = UseFormReturn<FormSchemaType, unknown, undefined>;
@@ -40,6 +42,10 @@ const SignupFormSchema = z
 export const useSignupForm = () => {
   const searchParams = useSearchParams();
   const email = searchParams.get("email") || "";
+  const token = searchParams.get("token") || "";
+
+  const { mutate, error } = useMutationAdminSignup();
+
   const router = useRouter();
 
   const form = useForm<FormSchemaType>({
@@ -52,12 +58,28 @@ export const useSignupForm = () => {
     mode: "onChange",
   });
 
-  const onSubmit = async () => {
-    router.replace("/login");
+  const onSubmit = async (data: FormSchemaType) => {
+    const { email, password } = data;
+
+    mutate(
+      {
+        email,
+        password,
+        token,
+      },
+      {
+        onSuccess: async () => {
+          router.replace("/");
+        },
+      },
+    );
   };
 
   return {
     form,
     onSubmit,
+    error: error
+      ? error.response.data.message || "Unknwon Error has Occured"
+      : null,
   };
 };

--- a/packages/api/src/admin-auth.ts
+++ b/packages/api/src/admin-auth.ts
@@ -6,7 +6,10 @@ import {
 } from "@uket/api/types/admin-auth";
 import { fetcherAdmin } from "../../../packages/api/src/admin-instance";
 
-export const adminLogin = async ({ email, password }: AdminLoginRequestParams) => {
+export const adminLogin = async ({
+  email,
+  password,
+}: AdminLoginRequestParams) => {
   const { data } = await fetcherAdmin.post<AdminLoginResponse>(`/users/login`, {
     email,
     password,
@@ -15,16 +18,36 @@ export const adminLogin = async ({ email, password }: AdminLoginRequestParams) =
   return data;
 };
 
+// export const adminSignup = async ({
+//   email,
+//   password,
+// }: AdminSignupRequestParams) => {
+//   const { data } = await fetcherAdmin.post<AdminSignupResponse>(
+//     `/users/password`,
+//     {
+//       email,
+//       password,
+//     },
+//   );
+
+//   return data;
+// };
+
 export const adminSignup = async ({
   email,
   password,
-  name,
-}: AdminSignupRequestParams) => {
-  const { data } = await fetcherAdmin.post<AdminSignupResponse>(`/auth/signup`, {
-    email,
-    password,
-    name,
-  });
+  token,
+}: AdminSignupRequestParams & { token: string }) => {
+  const { data } = await fetcherAdmin.post<AdminSignupResponse>(
+    `/users/password`,
+    { email, password },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      mode: "TOAST_UI",
+    },
+  );
 
   return data;
 };

--- a/packages/api/src/admin-auth.ts
+++ b/packages/api/src/admin-auth.ts
@@ -18,21 +18,6 @@ export const adminLogin = async ({
   return data;
 };
 
-// export const adminSignup = async ({
-//   email,
-//   password,
-// }: AdminSignupRequestParams) => {
-//   const { data } = await fetcherAdmin.post<AdminSignupResponse>(
-//     `/users/password`,
-//     {
-//       email,
-//       password,
-//     },
-//   );
-
-//   return data;
-// };
-
 export const adminSignup = async ({
   email,
   password,

--- a/packages/api/src/mutations/use-mutation-admin-signup.ts
+++ b/packages/api/src/mutations/use-mutation-admin-signup.ts
@@ -1,0 +1,18 @@
+import { AdminSignupRequestParams } from "@uket/api/types/admin-auth";
+
+import { useMutation } from "@tanstack/react-query";
+import { adminSignup } from "../admin-auth";
+
+export const useMutationAdminSignup = () => {
+  const mutation = useMutation({
+    mutationFn: ({
+      email,
+      password,
+      token,
+    }: AdminSignupRequestParams & { token: string }) =>
+      adminSignup({ email, password, token }),
+    throwOnError: false,
+  });
+
+  return mutation;
+};

--- a/packages/api/src/types/admin-auth.ts
+++ b/packages/api/src/types/admin-auth.ts
@@ -11,11 +11,13 @@ export type AdminLoginResponse = {
   authority: string;
 };
 
-export type AdminSignupRequestParams = {
-  name: string;
-} & AccountInfo;
+export type AdminSignupRequestParams = {} & AccountInfo;
 
 export type AdminSignupResponse = {
   adminId: number;
+  organization: string;
   name: string;
+  email: string;
+  password: string;
+  isSuperAdmin: boolean;
 };


### PR DESCRIPTION
## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 어드민 회원가입 api 연결
- [x] 어드민 모바일 회원가입 스타일 변경 

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점
- 회원가입용 api로 요청을 보낼때, 사용자가 이메일을 타고 이동하는 url의 파라미터에 담겨있는 token을 함께 보내야하는데요.
"기존 토큰 및 쿠키처럼 get, set 방식을 이용할까?" 고민했지만 사용자가 회원가입을 시도하는 때에 파라미터로 사용자한테도 보이기 때문에 바로 헤더에 넣는 방식을 택했습니다.
이 부분에 대해서 편하게 의견주시면 반영하겠습니다!

## 💬 리뷰 요구사항(선택)

