### PR TITLE
fix/UKET-130: 어드민 초대메일을 통한 회원가입 에러 픽스

### DIFF
--- a/packages/util/src/path.ts
+++ b/packages/util/src/path.ts
@@ -21,7 +21,6 @@ const DYNAMIC_AUTH_REQUIRED_PATH = [
 const ADMIN_STATIC_AUTH_REQUIRED_PATH = [
   "/users",
   "/users/info",
-  "/users/password",
   "/users/register",
   "/organizations",
   "/uket-event-registrations",


### PR DESCRIPTION
## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 회원가입 에러 픽스

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점
- 초대메일을 통해 사용하는 토큰은 24시간만 유효하고, 회원가입 이후에는 사용할 일이 없어 따로 프론트 측에서 관리하지 않도록 했습니다!
- 따라서 인증이 필요한 path에서 제거했습니다.

## 💬 리뷰 요구사항(선택)

