### PR TITLE
feat/UKET-121: 행사 수정 페이지 레이아웃 제작 및 행사 수정 API 연동

### DIFF
--- a/apps/admin/app/(main)/event-manage/_components/event-add-section.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/event-add-section.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { Form } from "@ui/components/ui/form";
+import { useQueryAdminEventInfoDetail } from "@uket/api/queries/admin-event-info";
 import { useFunnel } from "@use-funnel/browser";
 import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
@@ -12,6 +13,10 @@ import {
   PaymentSchema,
   useAddEventForm,
 } from "../../../../hooks/use-add-event-form";
+
+interface EventAddSectionProps {
+  eventId?: string;
+}
 
 const StepBasicInfo = dynamic(() => import("./step/step-basic-info"), {
   ssr: false,
@@ -25,8 +30,12 @@ const StepPaymentInfo = dynamic(() => import("./step/step-payment-info"), {
   ssr: false,
 });
 
-export default function EventAddSection() {
-  const { form, onSubmit } = useAddEventForm();
+export default function EventAddSection({ eventId }: EventAddSectionProps) {
+  const { data } = useQueryAdminEventInfoDetail(eventId);
+  const { form, onSubmit } = useAddEventForm({
+    initialData: data?.data,
+    eventId,
+  });
   const searchParams = useSearchParams();
 
   const funnel = useFunnel({
@@ -56,7 +65,7 @@ export default function EventAddSection() {
       funnel.history.replace("기본정보");
     }
   }, []);
-  
+
   return (
     <section className="w-full h-3/4 rounded-lg flex">
       <Form {...form}>

--- a/apps/admin/app/(main)/event-manage/_components/event-add-section.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/event-add-section.tsx
@@ -114,6 +114,7 @@ export default function EventAddSection({ eventId }: EventAddSectionProps) {
               uketEventImage={context.uketEventImageId}
               thumbnailImage={context.thumbnailImageId}
               bannerImageList={context.banners}
+              isModify={eventId !== undefined}
             />
           )}
         />

--- a/apps/admin/app/(main)/event-manage/_components/event-table-section.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/event-table-section.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
@@ -5,11 +6,12 @@ import { Badge } from "@ui/components/ui/badge";
 import { cn } from "@ui/lib/utils";
 import { useQueryAdminEventInfoList } from "@uket/api/queries/admin-event-info";
 import { Content } from "@uket/api/types/admin-event";
+import { useRouter } from "next/navigation";
 import { useMemo } from "react";
 import StatusSelector from "../../../../components/status-selector";
 import { useEventManageParams } from "../../../../hooks/use-event-manage-params";
-import EventTypeFilter, { EventType } from "./event-type-filter";
 import EventTable from "./event-table";
+import EventTypeFilter, { EventType } from "./event-type-filter";
 
 export type Entry = Content;
 
@@ -17,7 +19,7 @@ export const columns = (
   pageIndex: number,
   selectedEventType: EventType,
   isSuperAdmin: boolean,
-  setSelectedEventType: (value: EventType) => void
+  setSelectedEventType: (value: EventType) => void,
 ): ColumnDef<Entry>[] => [
   {
     id: "rowNumber",
@@ -94,7 +96,9 @@ export const columns = (
     accessorKey: "eventInfo",
     header: () => <div>행사 정보</div>,
     cell: ({ row }) => {
+      const eventId = row.original.uketEventRegistrationId;
       const isEditable = row.original.isModifiable;
+      const router = useRouter();
 
       const style = isEditable
         ? "bg-[#F0EDFD] text-brand hover:bg-[#F0EDFD]"
@@ -108,6 +112,10 @@ export const columns = (
             "h-8 w-28 justify-center rounded-lg text-base cursor-pointer font-medium",
             style,
           )}
+          onClick={() => {
+            if (!isEditable) return;
+            router.push(`/event-manage/modify/${eventId}`);
+          }}
         >
           {content}
         </Badge>
@@ -116,7 +124,11 @@ export const columns = (
   },
 ];
 
-export default function EventTableSection({isSuperAdmin = false}: {isSuperAdmin?: boolean}) {
+export default function EventTableSection({
+  isSuperAdmin = false,
+}: {
+  isSuperAdmin?: boolean;
+}) {
   const { page, eventType, updateQuery } = useEventManageParams();
 
   const { data: events } = useQueryAdminEventInfoList({

--- a/apps/admin/app/(main)/event-manage/_components/step/step-payment-info.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/step/step-payment-info.tsx
@@ -21,6 +21,7 @@ interface StepPaymentInfoProps {
   uketEventImage: FieldValues["uketEventImageId"];
   thumbnailImage: FieldValues["thumbnailImageId"];
   bannerImageList: FieldValues["banners"];
+  isModify?: boolean;
 }
 
 export default function StepPaymentInfo({
@@ -30,6 +31,7 @@ export default function StepPaymentInfo({
   uketEventImage,
   thumbnailImage,
   bannerImageList,
+  isModify = false,
 }: StepPaymentInfoProps) {
   const { control, setValue, trigger } = useFormContext();
   const isFree = useWatch({
@@ -89,6 +91,7 @@ export default function StepPaymentInfo({
       setValue("paymentInfo.depositorName", "");
       setValue("paymentInfo.depositUrl", "");
     } else {
+      if (isModify) return;
       setValue("paymentInfo.ticketPrice", 100);
       setValue("paymentInfo.bankCode", undefined);
       setValue("paymentInfo.accountNumber", undefined);

--- a/apps/admin/app/(main)/event-manage/modify/[id]/page.tsx
+++ b/apps/admin/app/(main)/event-manage/modify/[id]/page.tsx
@@ -1,0 +1,27 @@
+import { HydrationBoundary } from "@uket/api";
+import { prefetchAdminEventInfoDetail } from "@uket/api/queries/admin-event-info";
+import { Suspense } from "react";
+import EventAddSection from "../../_components/event-add-section";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const state = prefetchAdminEventInfoDetail(id);
+
+  return (
+    <HydrationBoundary state={state}>
+      <main className="flex h-full flex-col grow gap-5 pl-16 pr-20 pt-20">
+        <div className="flex items-end justify-between">
+          <h1 className="text-[34px] font-bold">행사 정보 수정</h1>
+        </div>
+        <Suspense>
+          <EventAddSection eventId={id} />
+        </Suspense>
+      </main>
+    </HydrationBoundary>
+  );
+}

--- a/apps/admin/hooks/use-add-event-form.ts
+++ b/apps/admin/hooks/use-add-event-form.ts
@@ -132,13 +132,22 @@ export const PaymentSchema = EventInfoSchema.required({
   banners: true,
 });
 
-export const useAddEventForm = () => {
-  const { mutateAsync } = useMutationSubmitEvent();
+export const useAddEventForm = ({
+  initialData,
+  eventId,
+}: {
+  initialData?: BaseSchemaType;
+  eventId?: string;
+}) => {
+  const { mutateAsync } = useMutationSubmitEvent({
+    methodType: eventId ? "modify" : "add",
+    eventId,
+  });
 
   const form = useForm<BaseSchemaType>({
     resolver: zodResolver(BaseSchema),
     mode: "onChange",
-    defaultValues: {
+    defaultValues: initialData || {
       eventType: "공연",
       organization: "",
       organizationId: undefined,

--- a/packages/api/src/mutations/use-mutation-submit-event.ts
+++ b/packages/api/src/mutations/use-mutation-submit-event.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { format } from "@uket/util/time";
 import { fetcherAdmin } from "../admin-instance";
 import { AdminUserInfoResponse } from "../types/admin-auth";
-type EventType = "공연" | "축제";
+export type EventType = "공연" | "축제";
 
 type EventRound = {
   date: Date;
@@ -39,7 +39,7 @@ type ImageId = {
   id?: string | null | undefined;
 };
 
-type PaymentInfo = {
+export type PaymentInfo = {
   isFree: "무료" | "유료";
   ticketPrice: number;
   bankCode: string;
@@ -69,7 +69,18 @@ type SubmitEventResponse = {
   eventType: "FESTIVAL" | "PERFORMANCE";
 };
 
-export const useMutationSubmitEvent = () => {
+export const useMutationSubmitEvent = (
+  {
+    methodType,
+    eventId,
+  }: {
+    methodType?: "modify" | "add";
+    eventId?: string;
+  } = {
+    methodType: "add",
+    eventId: undefined,
+  },
+) => {
   const mutation = useMutation({
     mutationFn: async ({ params }: { params: SubmitEventRequestParams }) => {
       const {
@@ -138,15 +149,26 @@ export const useMutationSubmitEvent = () => {
               festivalData: formattedData,
             };
 
-      const { data } = await fetcherAdmin.post<SubmitEventResponse>(
-        `/uket-event-registrations/organizations/${organizationId}/event-type/${type}`,
-        body,
-        {
-          mode: "TOAST_UI",
-        },
-      );
+      let response;
+      if (methodType === "add") {
+        response = await fetcherAdmin.post<SubmitEventResponse>(
+          `/uket-event-registrations/organizations/${organizationId}/event-type/${type}`,
+          body,
+          {
+            mode: "TOAST_UI",
+          },
+        );
+      } else {
+        response = await fetcherAdmin.put<SubmitEventResponse>(
+          `/uket-event-registrations/${eventId}/event-type/${type}`,
+          body,
+          {
+            mode: "TOAST_UI",
+          },
+        );
+      }
 
-      return data;
+      return response.data;
     },
   });
 

--- a/packages/api/src/queries/admin-event-info.ts
+++ b/packages/api/src/queries/admin-event-info.ts
@@ -1,8 +1,15 @@
+/* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
+/* eslint-disable react-hooks/rules-of-hooks */
 import { createQueryKeys } from "@lukemorales/query-key-factory";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { dehydrate, useSuspenseQuery } from "@tanstack/react-query";
 import { formatDate } from "@uket/util/time";
 import { fetcherAdmin } from "../admin-instance";
-import { AdminTicketInfoResponse } from "../types/admin-event";
+import { getQueryClient } from "../get-query-client";
+import { EventType, PaymentInfo } from "../mutations/use-mutation-submit-event";
+import {
+  AdminTicketDetailInfoResponse,
+  AdminTicketInfoResponse,
+} from "../types/admin-event";
 
 const DEFAULT_PAGE_NUMBER = 0;
 const DEFAULT_PAGE_SIZE = 10;
@@ -25,10 +32,25 @@ const getAdminEventInfoList = async ({
   return data;
 };
 
+const getAdminEventInfoDetail = async (id: string) => {
+  const { data } = await fetcherAdmin.get<AdminTicketDetailInfoResponse>(
+    `/uket-event-registrations/${id}`,
+    {
+      mode: "BOUNDARY",
+    },
+  );
+
+  return data;
+};
+
 export const adminEventInfo = createQueryKeys("admin-event-info", {
   list: ({ page, size }) => ({
     queryKey: [page],
     queryFn: () => getAdminEventInfoList({ page, size }),
+  }),
+  detail: (id: string) => ({
+    queryKey: [id],
+    queryFn: () => getAdminEventInfoDetail(id),
   }),
 });
 
@@ -57,4 +79,86 @@ export const useQueryAdminEventInfoList = ({
       };
     },
   });
+};
+
+export const useQueryAdminEventInfoDetail = (id: string | undefined) => {
+  if (!id) {
+    return { data: null };
+  }
+
+  return useSuspenseQuery({
+    ...adminEventInfo.detail(id),
+    select: data => {
+      const eventType = (
+        data.eventType === "FESTIVAL" ? "축제" : "공연"
+      ) as EventType;
+      const eventInfo =
+        data.eventType === "PERFORMANCE"
+          ? data.performanceData
+          : data.festivalData;
+      const ticketingDate = {
+        ticketingStartDateTime: new Date(eventInfo?.ticketingStartDateTime!),
+        ticketingEndDateTime: new Date(eventInfo?.ticketingEndDateTime!),
+      };
+      const eventRound = eventInfo?.eventRound.map(item => {
+        const [hours, minutes] = item.startTime.split(":").map(Number);
+        const date = new Date(item.date);
+        date.setHours(hours!, minutes!, 0, 0);
+
+        return {
+          date,
+          startTime: item.startTime,
+        };
+      });
+      const paymentInfo = {
+        isFree: (eventInfo?.paymentInfo.ticketPrice === 0
+          ? "무료"
+          : "유료") as PaymentInfo["isFree"],
+        ...eventInfo?.paymentInfo!,
+      };
+      const uketEventImageId = {
+        file: undefined,
+        previewImage: undefined,
+        id: eventInfo?.uketEventImageId,
+      };
+      const thumbnailImageId = {
+        file: undefined,
+        previewImage: undefined,
+        id: eventInfo?.thumbnailImageId,
+      };
+      const banners = eventInfo?.banners.map(item => {
+        return {
+          file: undefined,
+          previewImage: undefined,
+          link: item.link,
+          id: item.imageId.toString(),
+        };
+      });
+      const location = {
+        base: eventInfo?.location!,
+        detail: "",
+      };
+      return {
+        eventType: data.eventType,
+        data: {
+          ...eventInfo,
+          eventType,
+          ticketingDate,
+          paymentInfo,
+          uketEventImageId,
+          thumbnailImageId,
+          banners,
+          location,
+          eventRound,
+        },
+      };
+    },
+  });
+};
+
+export const prefetchAdminEventInfoDetail = (id: string) => {
+  const queryClient = getQueryClient();
+  queryClient.prefetchQuery({ ...adminEventInfo.detail(id) });
+
+  return dehydrate(queryClient);
 };

--- a/packages/api/src/types/admin-event.ts
+++ b/packages/api/src/types/admin-event.ts
@@ -1,4 +1,9 @@
-export type EventStatus = "검수 진행" | "검수 완료" | "행사 완료" | "등록 완료" | "등록 취소";
+export type EventStatus =
+  | "검수 진행"
+  | "검수 완료"
+  | "행사 완료"
+  | "등록 완료"
+  | "등록 취소";
 
 interface EventStatusInfo {
   value: string;
@@ -57,8 +62,51 @@ export interface PaginationMeta {
   empty: boolean;
 }
 
+export interface AdminTicketDetail {
+  eventName: string;
+  location: string;
+  eventRound: {
+    date: Date;
+    startTime: string;
+  }[];
+  ticketingStartDateTime: string;
+  ticketingEndDateTime: string;
+  entryGroup: {
+    ticketCount: number;
+    entryStartTime: string;
+  }[];
+  totalTicketCount: number;
+  details: {
+    information: string;
+    caution: string;
+  };
+  contact: {
+    type: string;
+    content: string;
+    link: string;
+  };
+  uketEventImageId: string;
+  thumbnailImageId: string;
+  banners: {
+    imageId: number;
+    link: string;
+  }[];
+  paymentInfo: {
+    ticketPrice: number;
+    bankCode: string;
+    accountNumber: string;
+    depositorName: string;
+    depositUrl: string;
+  };
+}
 export interface AdminTicketInfoResponse extends PaginationMeta {
   content: Content[];
+}
+
+export interface AdminTicketDetailInfoResponse {
+  eventType: "FESTIVAL" | "PERFORMANCE";
+  festivalData: AdminTicketDetail | null;
+  performanceData: AdminTicketDetail | null;
 }
 
 export interface ChangeEventStatusParams {

--- a/packages/util/src/path.ts
+++ b/packages/util/src/path.ts
@@ -36,6 +36,7 @@ const ADMIN_DYNAMIC_AUTH_REQUIRED_PATH = [
   /^\/users\/([^/]+)$/,
   /^\/uket-event-registrations\/([^/]+)$/,
   /^\/uket-event-registrations\/([^/]+)\/status\/([^/]+)$/,
+  /^\/uket-event-registrations\/([^/]+)\/event-type\/([^/]+)$/,
   /^\/uket-event-registrations\/organizations\/([^/]+)\/event-type\/([^/]+)$/,
   /^\/(\d+)\/status\/([^/]+)$/,
 ];


### PR DESCRIPTION
## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 행사 수정 페이지 레이아웃 제작 (라우트 추가)
- [x] 행사 수정 API 추가
- [x] 특정 행사 조회 API 추가
## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점
### 행사 수정 시나리오
1. 행사 수정 페이지 진입
2. 특정 행사 조회 API로 행사 데이터 호출
3. useAddEventForm에 행사 데이터 전달 >> 행사 추가 스키마의 defaultValues로 사용됨

API로 가져온 행사 데이터에서 이미지 관련 필드는 이미지 아이디를 보내주고 있습니다. 이는 이미지 호출 API를 통해 실제 이미지를 가져와야 하는데 아직 백엔드에서 배포가 되지 않았습니다.
그래서 테스트 과정에서, 이미지 필드에는 이미지 값이 적용되어 있지 않습니다.

이 부분은 이미지 호출 API 배포가 되면 추가할 예정입니다.
## 💬 리뷰 요구사항(선택)

