### PR TITLE
fix/UKET-149: 유저/어드민 티켓 상태값 추가(환불요청)

### DIFF
--- a/apps/admin/components/status-selector.tsx
+++ b/apps/admin/components/status-selector.tsx
@@ -2,6 +2,7 @@ import { useMutationChangeEventStatus } from "@uket/api/mutations/use-mutation-c
 import { useMutationChangeTicketStatus } from "@uket/api/mutations/use-mutation-change-ticket-status";
 import { EVENT_STATUS_INFO, EventStatus } from "@uket/api/types/admin-event";
 import { TICKET_STATUS_INFO } from "@uket/api/types/admin-ticket";
+import { TicketStatus } from "@uket/api/types/ticket";
 import {
   NonSelectTrigger,
   Select,
@@ -12,6 +13,7 @@ import {
 } from "@uket/ui/components/ui/select";
 import { useState } from "react";
 import { getNextEventStatusOptions } from "../hooks/use-next-event-options";
+import { getNextTicketStatusOptions } from "../hooks/use-next-ticket-options";
 import StatusChangeDialog from "./status-change-dialog";
 
 interface TicketStatusSelectorProps {
@@ -36,7 +38,7 @@ export default function StatusSelector({
 
   const getFilteredOptions = () => {
     return isTicket
-      ? TICKET_STATUS_INFO
+      ? getNextTicketStatusOptions(currentItem.text as TicketStatus)
       : getNextEventStatusOptions(currentItem.text as EventStatus);
   };
 

--- a/apps/admin/hooks/use-next-ticket-options.ts
+++ b/apps/admin/hooks/use-next-ticket-options.ts
@@ -1,0 +1,34 @@
+import {
+  TICKET_STATUS_INFO,
+  TicketStatusInfo,
+} from "@uket/api/types/admin-ticket";
+import { TicketStatus } from "@uket/api/types/ticket";
+
+const NEXT_STATUS_MAP: Record<TicketStatus, TicketStatus[]> = {
+  "입금 확인중": ["예매 완료"],
+  "예매 완료": ["입장 완료"],
+  "입장 완료": ["기간 만료"],
+  "기간 만료": ["환불 요청"],
+  "환불 요청": ["예매 취소"],
+  "예매 취소": [],
+};
+
+export const getNextTicketStatusOptions = (
+  currentStatus: TicketStatus,
+): TicketStatusInfo[] => {
+  const currentItem = TICKET_STATUS_INFO.find(
+    item => item.text === currentStatus,
+  )!;
+
+  const nextStatuses = NEXT_STATUS_MAP[currentStatus] || [];
+
+  let options = TICKET_STATUS_INFO.filter(item =>
+    nextStatuses.includes(item.text as TicketStatus),
+  );
+
+  if (!options.find(item => item.text === currentStatus)) {
+    options = [currentItem, ...options];
+  }
+
+  return options;
+};

--- a/apps/admin/hooks/use-next-ticket-options.ts
+++ b/apps/admin/hooks/use-next-ticket-options.ts
@@ -7,8 +7,8 @@ import { TicketStatus } from "@uket/api/types/ticket";
 const NEXT_STATUS_MAP: Record<TicketStatus, TicketStatus[]> = {
   "입금 확인중": ["예매 완료"],
   "예매 완료": ["입장 완료"],
-  "입장 완료": ["기간 만료"],
-  "기간 만료": ["환불 요청"],
+  "입장 완료": [],
+  "기간 만료": [],
   "환불 요청": ["예매 취소"],
   "예매 취소": [],
 };

--- a/apps/web/app/(auth)/ticket-list/_components/confirm-modal.tsx
+++ b/apps/web/app/(auth)/ticket-list/_components/confirm-modal.tsx
@@ -16,12 +16,18 @@ import { useState } from "react";
 
 interface ConfirmModalProps {
   ticketId: number;
+  ticketStatus: string;
 }
 
-export default function ConfirmModal({ ticketId }: ConfirmModalProps) {
+export default function ConfirmModal({
+  ticketId,
+  ticketStatus,
+}: ConfirmModalProps) {
   const queryClient = getQueryClient();
   const [open, setOpen] = useState(false);
   const { mutate } = useMutationCancelTicket();
+
+  const bookingConfirmed = ticketStatus === "예매 완료";
 
   const handleCancelTicket = () => {
     setOpen(false);
@@ -47,7 +53,19 @@ export default function ConfirmModal({ ticketId }: ConfirmModalProps) {
               정말 예매를 취소하시겠어요?
             </DialogTitle>
             <DialogDescription className="flex flex-col text-center">
-              <span>환불 문의는 공연 담당자에게 연락바랍니다.</span>
+              {bookingConfirmed ? (
+                <>
+                  <span>환불 처리를 위해 입금 받으실 계좌 정보를</span>
+                  <span>UKET 공식 채널로 전달해주세요.</span>
+                </>
+              ) : (
+                <>
+                  <span>
+                    입금을 완료하셨는데 <strong>입금 확인중</strong>상태라면,
+                  </span>
+                  <span>UKET 공식 채널에 환불 계좌 정보를 보내주세요.</span>
+                </>
+              )}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="flex-row items-center justify-center gap-3">

--- a/apps/web/app/(auth)/ticket-list/_components/confirm-modal.tsx
+++ b/apps/web/app/(auth)/ticket-list/_components/confirm-modal.tsx
@@ -54,17 +54,19 @@ export default function ConfirmModal({
             </DialogTitle>
             <DialogDescription className="flex flex-col text-center">
               {bookingConfirmed ? (
-                <>
-                  <span>환불 처리를 위해 입금 받으실 계좌 정보를</span>
-                  <span>UKET 공식 채널로 전달해주세요.</span>
-                </>
+                <div className="leading-1">
+                  환불 처리를 위해 입금 받으실 계좌 정보를
+                  <br />
+                  UKET 공식 채널로 전달해주세요.
+                </div>
               ) : (
-                <>
-                  <span>
-                    입금을 완료하셨는데 <strong>입금 확인중</strong>상태라면,
+                <div className="leading-1">
+                  입금을 완료하셨는데 <strong>입금 확인중</strong>상태라면,
+                  <br />
+                  <span className="whitespace-nowrap">
+                    UKET 공식 채널에 환불 계좌 정보를 보내주세요.
                   </span>
-                  <span>UKET 공식 채널에 환불 계좌 정보를 보내주세요.</span>
-                </>
+                </div>
               )}
             </DialogDescription>
           </DialogHeader>

--- a/apps/web/app/(auth)/ticket-list/_components/ticket-modal.tsx
+++ b/apps/web/app/(auth)/ticket-list/_components/ticket-modal.tsx
@@ -12,8 +12,8 @@ import dynamic from "next/dynamic";
 import QrcodeDepositErrorFallback from "../../../../components/error-fallback/qrcode-deposit-error-fallback";
 import Indicator from "../../../../components/indicator";
 import RetryApiErrorBoundary from "../../../../components/retry-api-error-boundary";
-import GridItem from "./grid-item";
 import Deposit from "./deposit";
+import GridItem from "./grid-item";
 import Qrcode from "./qr-code";
 
 const ConfirmModal = dynamic(() => import("./confirm-modal"));
@@ -75,6 +75,16 @@ export default function TicketModal({
                 </h2>
               </div>
             )}
+            {ticketStatus === "환불 요청" && (
+              <div className="flex flex-col items-center text-desc h-40 justify-center gap-2">
+                <h1 className="font-black text-xl">
+                  관리자에게 환불 요청을 보냈습니다!
+                </h1>
+                <h2 className="font-medium text-sm">
+                  추가 문의는 UKET 공식 채널을 이용해주세요.
+                </h2>
+              </div>
+            )}
           </RetryApiErrorBoundary>
         </CardDescription>
       </CardHeader>
@@ -103,7 +113,9 @@ export default function TicketModal({
           </section>
           <Separator className="bg-[#5E5E6E]" />
           <footer>
-            {isTicketCancelAvailable && <ConfirmModal ticketId={ticketId} />}
+            {isTicketCancelAvailable && (
+              <ConfirmModal ticketId={ticketId} ticketStatus={ticketStatus} />
+            )}
           </footer>
         </section>
       </CardContent>

--- a/apps/web/app/(auth)/ticket-list/_components/ticket.tsx
+++ b/apps/web/app/(auth)/ticket-list/_components/ticket.tsx
@@ -86,7 +86,10 @@ export default function Ticket({ ticket }: TicketProps) {
                   />
                 </div>
                 {isTicketCancelAvailable ? (
-                  <ConfirmModal ticketId={ticket.ticketId} />
+                  <ConfirmModal
+                    ticketId={ticket.ticketId}
+                    ticketStatus={ticket.ticketStatus}
+                  />
                 ) : (
                   <div className="py-5"></div>
                 )}

--- a/apps/web/components/indicator.tsx
+++ b/apps/web/components/indicator.tsx
@@ -15,6 +15,7 @@ const VARIANT_MAPPING: Record<string, BadgeVariant> = {
   "입금 확인중": "deposit",
   "예매 완료": "reservation",
   "입장 완료": "enter",
+  "환불 요청": "refund",
 };
 
 export default function Indicator({

--- a/packages/api/src/types/admin-ticket.ts
+++ b/packages/api/src/types/admin-ticket.ts
@@ -15,7 +15,7 @@ export const USER_TYPE: TicketUserOption[] = [
   { text: "재학생", value: TicketUserType.STUDENT },
 ];
 
-interface TicketStatusInfo {
+export interface TicketStatusInfo {
   value: string;
   text: TicketStatus | "예매 취소";
   color: string;
@@ -38,6 +38,11 @@ export const TICKET_STATUS_INFO: TicketStatusInfo[] = [
     color: "rgba(153, 129, 254, 0.9)",
   },
   { value: "EXPIRED", text: "기간 만료", color: "rgba(204, 204, 204, 0.9)" },
+  {
+    value: "REFUND_REQUESTED",
+    text: "환불 요청",
+    color: "rgba(253, 154, 129, 0.9)",
+  },
   {
     value: "RESERVATION_CANCEL",
     text: "예매 취소",

--- a/packages/api/src/types/ticket.ts
+++ b/packages/api/src/types/ticket.ts
@@ -1,4 +1,10 @@
-export type TicketStatus = "입금 확인중" | "예매 완료" | "입장 완료" | "기간 만료";
+export type TicketStatus =
+  | "입금 확인중"
+  | "예매 완료"
+  | "입장 완료"
+  | "기간 만료"
+  | "환불 요청"
+  | "예매 취소";
 
 export type TicketItem = {
   userName: string;

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@uket/ui/lib/utils";
 
@@ -22,6 +22,8 @@ const badgeVariants = cva(
           "border-transparent bg-desc text-[#9981FE] w-22 gap-1 items-center after:content-[''] after:w-2 after:h-2 after:bg-[#9981FE] after:rounded-full",
         deposit:
           "border-transparent bg-desc text-[#FFEF60] w-22 gap-1 items-center after:content-[''] after:w-2 after:h-2 after:bg-[#FFEF60] after:rounded-full",
+        refund:
+          "border-transparent bg-desc text-[#FD9A81] w-22 gap-1 items-center after:content-[''] after:w-2 after:h-2 after:bg-[#FD9A81] after:rounded-full",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 유저 티켓 상태값 추가
- [x] 어드민 티켓 상태값 추가

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점
- 현재 백엔드 어드민 쪽 에러로 인해 직접 테스트는 어려우실 수 있습니다. 아래 영상으로 확인 부탁드립니다.
- 참고로, 환불 요청 이후의 로직은 아직 백엔드에서 수정 중이라, 현재는 환불 요청 / 예매 완료 / 입금 확인중 세 가지 상태에 따른 모달 화면만 확인 가능합니다.

https://github.com/user-attachments/assets/02859f2e-ebc0-41e3-8958-c09518adc7d8


## 💬 리뷰 요구사항(선택)

