### PR TITLE
feat/UKET-213: 행사 등록 및 수정 폼에서 다음으로 버튼 수정

### DIFF
--- a/apps/admin/app/(main)/event-manage/_components/step-basic/event-calendar-field.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/step-basic/event-calendar-field.tsx
@@ -93,10 +93,11 @@ export default function EventCalendarField({
 
                             // Update both date and startTime
                             field.onChange(updatedDate);
-                            setValue(
-                              `eventRound.${index}.startTime`,
-                              format(updatedDate, "HH:mm:ss"),
-                            );
+                              setValue(
+                                `eventRound.${index}.startTime`,
+                                format(updatedDate, "HH:mm:ss"),
+                                { shouldValidate: true, shouldDirty: true, shouldTouch: true },
+                              );
                           }}
                           disabled={date => date < new Date()}
                           classNames={{
@@ -137,6 +138,7 @@ export default function EventCalendarField({
                                   setValue(
                                     `eventRound.${index}.startTime`,
                                     format(updatedDate, "HH:mm:ss"),
+                                    { shouldValidate: true, shouldDirty: true, shouldTouch: true },
                                   );
                                 }}
                               />

--- a/apps/admin/app/(main)/event-manage/_components/step-basic/zipcode-field.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/step-basic/zipcode-field.tsx
@@ -45,7 +45,11 @@ export default function ZipcodeField({
       }
       fullAddress += extraAddress !== "" ? ` (${extraAddress})` : "";
     }
-    onSetValue("location.base", fullAddress);
+    onSetValue("location.base", fullAddress, {
+      shouldValidate: true,
+      shouldDirty: true,
+      shouldTouch: true,
+    });
   };
 
   const handleClick = () => {

--- a/apps/admin/app/(main)/event-manage/_components/step/step-basic-info.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/step/step-basic-info.tsx
@@ -24,18 +24,29 @@ interface StepBasicInfoProps {
 }
 
 export default function StepBasicInfo({ onNext }: StepBasicInfoProps) {
-  const { control, setValue, trigger, watch } = useFormContext();
+  const { control, setValue, trigger, watch, formState, getFieldState } =
+    useFormContext();
   const eventType = useWatch({
     control,
     name: "eventType",
   });
   const allFieldValues = watch();
+  const hasBasicStepErrors =
+    getFieldState("eventType", formState).invalid ||
+    getFieldState("eventName", formState).invalid ||
+    getFieldState("eventRound", formState).invalid ||
+    getFieldState("ticketingDate", formState).invalid ||
+    getFieldState("location.base", formState).invalid ||
+    getFieldState("location.detail", formState).invalid ||
+    getFieldState("totalTicketCount", formState).invalid ||
+    getFieldState("entryGroup", formState).invalid;
 
   const handleNext = async () => {
     const isValid = await trigger(
       [
         "eventType",
         "eventName",
+        "eventRound",
         "ticketingDate",
         "location.base",
         "location.detail",
@@ -98,7 +109,11 @@ export default function StepBasicInfo({ onNext }: StepBasicInfoProps) {
           </section>
         </aside>
       </section>
-      <StepController onNext={handleNext} isFirstStep />
+      <StepController
+        onNext={handleNext}
+        isFirstStep
+        isNextDisabled={hasBasicStepErrors}
+      />
     </main>
   );
 }

--- a/apps/admin/app/(main)/event-manage/_components/step/step-basic-info.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/step/step-basic-info.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { Separator } from "@ui/components/ui/separator";
+import { useEffect } from "react";
 import { FieldValues, useFormContext, useWatch } from "react-hook-form";
 import EntryGroupField from "../step-basic/entry-group-field";
 import EventCalendarField from "../step-basic/event-calendar-field";
@@ -38,8 +40,25 @@ export default function StepBasicInfo({ onNext }: StepBasicInfoProps) {
     getFieldState("ticketingDate", formState).invalid ||
     getFieldState("location.base", formState).invalid ||
     getFieldState("location.detail", formState).invalid ||
-    getFieldState("totalTicketCount", formState).invalid ||
-    getFieldState("entryGroup", formState).invalid;
+    getFieldState("totalTicketCount", formState).invalid;
+
+  // 초기 마운트 시 필요한 필드 유효성 검사를 먼저 수행하여
+  // 비어있는 상태에서 "다음으로" 버튼이 활성화되지 않도록 함
+  useEffect(() => {
+    void trigger(
+      [
+        "eventType",
+        "eventName",
+        "eventRound",
+        "ticketingDate",
+        "location.base",
+        "location.detail",
+        "totalTicketCount",
+        "entryGroup",
+      ],
+      { shouldFocus: true },
+    );
+  }, []);
 
   const handleNext = async () => {
     const isValid = await trigger(

--- a/apps/admin/app/(main)/event-manage/_components/step/step-controller.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/step/step-controller.tsx
@@ -7,6 +7,7 @@ interface StepControllerProps {
   onPrev?: () => void;
   isFirstStep?: boolean;
   isLastStep?: boolean;
+  isNextDisabled?: boolean;
 }
 
 export default function StepController({
@@ -14,6 +15,7 @@ export default function StepController({
   onPrev,
   isFirstStep = false,
   isLastStep = false,
+  isNextDisabled = false,
 }: StepControllerProps) {
   return (
     <footer
@@ -33,6 +35,7 @@ export default function StepController({
         type={isLastStep ? "submit" : "button"}
         variant="ghost"
         className="hover:bg-gray-200 flex gap-1 text-brand"
+        disabled={isNextDisabled}
         onClick={onNext}
       >
         {isLastStep ? "제출하기" : "다음으로"}

--- a/apps/admin/app/(main)/event-manage/_components/step/step-event-info.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/step/step-event-info.tsx
@@ -27,13 +27,28 @@ interface StepEventInfoProps {
 }
 
 export default function StepEventInfo({ onPrev, onNext }: StepEventInfoProps) {
-  const { control, register, trigger, watch, setValue, getValues } =
-    useFormContext();
+  const {
+    control,
+    register,
+    trigger,
+    watch,
+    setValue,
+    getValues,
+    formState,
+    getFieldState,
+  } = useFormContext();
   const eventType = useWatch({
     control,
     name: "eventType",
   });
   const allFieldValues = watch();
+  const hasEventStepErrors =
+    getFieldState("details.information", formState).invalid ||
+    getFieldState("details.caution", formState).invalid ||
+    getFieldState("contact.type", formState).invalid ||
+    getFieldState("contact.content", formState).invalid ||
+    getFieldState("uketEventImageId.file", formState).invalid ||
+    getFieldState("thumbnailImageId.file", formState).invalid;
 
   const handleNext = async () => {
     const isValid = await trigger(
@@ -148,7 +163,11 @@ export default function StepEventInfo({ onPrev, onNext }: StepEventInfoProps) {
           </aside>
         </section>
       </section>
-      <StepController onPrev={onPrev} onNext={handleNext} />
+      <StepController
+        onPrev={onPrev}
+        onNext={handleNext}
+        isNextDisabled={hasEventStepErrors}
+      />
     </main>
   );
 }

--- a/apps/admin/app/(main)/event-manage/_components/step/step-payment-info.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/step/step-payment-info.tsx
@@ -41,7 +41,21 @@ export default function StepPaymentInfo({
     name: "paymentInfo.isFree",
   });
   const isDisabled = isFree === "무료";
+  const ticketPrice = useWatch({ control, name: "paymentInfo.ticketPrice" });
+  const bankCode = useWatch({ control, name: "paymentInfo.bankCode" });
+  const accountNumber = useWatch({ control, name: "paymentInfo.accountNumber" });
+  const depositorName = useWatch({ control, name: "paymentInfo.depositorName" });
+  const depositUrl = useWatch({ control, name: "paymentInfo.depositUrl" });
+
+  // 값 기반 즉시 검증(유료일 때 필수): 유효성 평가 이전에도 버튼 비활성화 보장
+  const hasRequiredEmptyWhenPaid =
+    isFree === "유료" && (
+      !ticketPrice || ticketPrice <= 0 ||
+      !bankCode || !accountNumber || !depositorName || !depositUrl
+    );
+
   const hasPaymentStepErrors =
+    hasRequiredEmptyWhenPaid ||
     getFieldState("paymentInfo.isFree", formState).invalid ||
     getFieldState("paymentInfo.ticketPrice", formState).invalid ||
     getFieldState("paymentInfo.bankCode", formState).invalid ||

--- a/apps/admin/app/(main)/event-manage/_components/step/step-payment-info.tsx
+++ b/apps/admin/app/(main)/event-manage/_components/step/step-payment-info.tsx
@@ -8,10 +8,10 @@ import {
   AddEventFormType,
   BaseSchemaType,
 } from "../../../../../hooks/use-add-event-form";
+import BuyTicketLimitField from "../step-payment/buy-ticket-limit-field";
 import PaymentCodeField from "../step-payment/payment-code-field";
 import PaymentInfoField from "../step-payment/payment-info-field";
 import PaymentTicketPriceField from "../step-payment/payment-ticket-price-field";
-import BuyTicketLimitField from "../step-payment/buy-ticket-limit-field";
 import StepController from "./step-controller";
 
 interface StepPaymentInfoProps {
@@ -34,12 +34,21 @@ export default function StepPaymentInfo({
   bannerImageList,
   isModify = false,
 }: StepPaymentInfoProps) {
-  const { control, setValue, trigger } = useFormContext();
+  const { control, setValue, trigger, formState, getFieldState } =
+    useFormContext();
   const isFree = useWatch({
     control,
     name: "paymentInfo.isFree",
   });
   const isDisabled = isFree === "무료";
+  const hasPaymentStepErrors =
+    getFieldState("paymentInfo.isFree", formState).invalid ||
+    getFieldState("paymentInfo.ticketPrice", formState).invalid ||
+    getFieldState("paymentInfo.bankCode", formState).invalid ||
+    getFieldState("paymentInfo.accountNumber", formState).invalid ||
+    getFieldState("paymentInfo.depositorName", formState).invalid ||
+    getFieldState("paymentInfo.depositUrl", formState).invalid ||
+    getFieldState("buyTicketLimit", formState).invalid;
 
   const { mutateAsync } = useMutationUploadImage();
 
@@ -58,7 +67,7 @@ export default function StepPaymentInfo({
         shouldFocus: true,
       },
     );
-    
+
     if (!isValid) return;
 
     const formData = new FormData();
@@ -142,7 +151,12 @@ export default function StepPaymentInfo({
             </aside>
           </section>
         </section>
-        <StepController onNext={handleNext} onPrev={onPrev} isLastStep />
+        <StepController
+          onNext={handleNext}
+          onPrev={onPrev}
+          isLastStep
+          isNextDisabled={hasPaymentStepErrors}
+        />
       </form>
     </main>
   );

--- a/apps/admin/hooks/use-add-event-form.ts
+++ b/apps/admin/hooks/use-add-event-form.ts
@@ -109,29 +109,28 @@ export const BaseSchema = z
     paymentInfo: z.object({
       isFree: z.enum(["무료", "유료"]).default("무료"),
       ticketPrice: z.number().default(100),
-      bankCode: z
-      .string({
-        message: "입금 은행을 선택해 주세요.",
-      })
-      .or(z.literal("")),
-      accountNumber: z
-      .string({
-        message: "입금 계좌를 입력해 주세요",
-      })
-      .or(z.literal("")),
-      depositorName: z
-      .string({
-        message: "예금주를 입력해 주세요",
-      })
-      .or(z.literal("")),
-      depositUrl: z
-      .string({
-        message: "송금 코드 링크를 입력해 주세요",
-      })
-      .url({
-        message: "형식에 맞지 않습니다.",
-      })
-      .or(z.literal("")),
+      bankCode: z.string().or(z.literal("")),
+      accountNumber: z.string().or(z.literal("")),
+      depositorName: z.string().or(z.literal("")),
+      depositUrl: z.string().url({ message: "형식에 맞지 않습니다." }).or(z.literal("")),
+    }).superRefine((val, ctx) => {
+      if (val.isFree === "유료") {
+        if (!val.ticketPrice || val.ticketPrice <= 0) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "티켓 가격을 입력해 주세요.", path: ["ticketPrice"] });
+        }
+        if (!val.bankCode) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "입금 은행을 선택해 주세요.", path: ["bankCode"] });
+        }
+        if (!val.accountNumber) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "입금 계좌를 입력해 주세요.", path: ["accountNumber"] });
+        }
+        if (!val.depositorName) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "예금주를 입력해 주세요.", path: ["depositorName"] });
+        }
+        if (!val.depositUrl) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "송금 코드 링크를 입력해 주세요.", path: ["depositUrl"] });
+        }
+      }
     }),
     noLimit: z.enum(["제한 없음", "제한"]).default("제한"),
     buyTicketLimit: z.number().default(1),

--- a/apps/admin/hooks/use-add-event-form.ts
+++ b/apps/admin/hooks/use-add-event-form.ts
@@ -4,6 +4,14 @@ import { useForm, UseFormReturn } from "react-hook-form";
 import { z } from "zod";
 import { useMutationSubmitEvent } from "../../../packages/api/src/mutations/use-mutation-submit-event";
 
+// HTML 문자열에서 텍스트만 추출하여 길이 검사에 사용
+const extractPlainText = (html?: string) =>
+  (html ?? "")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
 // 행사 등록 기본 스키마
 export const BaseSchema = z
   .object({
@@ -42,8 +50,16 @@ export const BaseSchema = z
         message: "티켓은 최소 1장 이상이어야 합니다.",
       }),
     details: z.object({
-      information: z.string().min(1),
-      caution: z.string().min(3),
+      information: z
+        .string()
+        .refine(v => extractPlainText(v).length >= 1, {
+          message: "상세 정보를 입력해 주세요.",
+        }),
+      caution: z
+        .string()
+        .refine(v => extractPlainText(v).length >= 3, {
+          message: "주의 사항을 3자 이상 입력해 주세요.",
+        }),
     }),
     contact: z.object({
       type: z.string(),


### PR DESCRIPTION
## ✅ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명 해주세요(이미지 첨부 가능)
- [x] 행사 등록 및 수정 폼의 각 단계에 다음으로/제출하기 버튼의 비활성화 및 활성화 로직 추가

## 🚦 특이 사항
> 주의깊게 봐야하는 PR 포인트 & 말하고 싶은 점

기존에는 입력 필드 실시간 검증없이 다음으로/제출하기 버튼이 항상 활성화 되어 있었습니다.
변경 후에는, 실시간으로 입력 필드를 검증하여 올바르지 않으면 다음 스텝으로 넘어가지 못하도록 변경했습니다.

## 💬 리뷰 요구사항(선택)

